### PR TITLE
Replace Joda-Time by Time4A

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ gradle.properties
 .idea/
 out/
 *.iml
+
+#key file
+/worldclockwidget/default_owm_api_key

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,7 @@
 World Clock & Weather
 =====================
-**This project is coming live again. All the upcoming updates will be mainted by** `Biswajit Das <https://github.com/dasbiswajit>`_
-
-
-**This new release require Users to signup for API Key. Please look for application Settings -> GENERAL -> !!!Important!!! section**
+** Important fix!!
+User can use default api key as well as signup API Keys. Please look for application Settings -> GENERAL -> !!!Important!!! section**
 
 A simple application to display the local time and current weather conditions in places all over the world.
 It comes with two home screen widgets which show weather and time or time only.

--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ The app uses and includes the following libraries:
 * `ActionBarSherlock <http://actionbarsherlock.com/>`_ (also on `GitHub <https://github.com/JakeWharton/ActionBarSherlock>`__)
 * `ColorPickerPreference <https://github.com/attenzione/android-ColorPickerPreference>`_
 * `google-gson <https://code.google.com/p/google-gson/>`_
-* `joda-time-android <https://github.com/dlew/joda-time-android>`_
+* `Time4A <https://github.com/MenoData/Time4A>`_
 
 Acknowledgements
 ----------------

--- a/worldclockwidget/build.gradle
+++ b/worldclockwidget/build.gradle
@@ -109,7 +109,7 @@ dependencies{
     compile 'com.actionbarsherlock:actionbarsherlock:4.4.0@aar'
     compile 'com.android.support:support-v4:19.1.0'
     compile 'com.google.code.gson:gson:2.3.1'
-    compile group: 'net.time4j', name: 'time4j-android', version: '3.41-2018d'
+    compile group: 'net.time4j', name: 'time4j-android', version: '4.0-2018g'
 }
 
 

--- a/worldclockwidget/build.gradle
+++ b/worldclockwidget/build.gradle
@@ -90,7 +90,7 @@ def getOpenWeatherMapApiKey() {
     if (project.hasProperty('owmApiKey')) {
         return owmApiKey
     } else {
-        def apiKeyFile = file('default_owm_api_key');
+        def apiKeyFile = file('default_owm_api_key')
         if (apiKeyFile.isFile()) {
           return apiKeyFile.text.trim()
         }
@@ -109,7 +109,7 @@ dependencies{
     compile 'com.actionbarsherlock:actionbarsherlock:4.4.0@aar'
     compile 'com.android.support:support-v4:19.1.0'
     compile 'com.google.code.gson:gson:2.3.1'
-    compile 'net.danlew:android.joda:2.9.4.1'
+    compile group: 'net.time4j', name: 'time4j-android', version: '3.41-2018d'
 }
 
 

--- a/worldclockwidget/proguard-project.txt
+++ b/worldclockwidget/proguard-project.txt
@@ -42,5 +42,3 @@
 #   public *;
 #}
 
-# ignore missing Joda time references
--dontwarn org.joda.time.tz.ZoneInfoCompiler,org.joda.convert.*

--- a/worldclockwidget/src/main/assets/city_data.csv
+++ b/worldclockwidget/src/main/assets/city_data.csv
@@ -1620,6 +1620,7 @@ Kishangarh	Kishangarh	26.59006	74.85397	India	Asia/Kolkata
 Kolār	Kolar	13.13768	78.12999	India	Asia/Kolkata
 Kolhāpur	Kolhapur	16.69563	74.23167	India	Asia/Kolkata
 Kolkata	Kolkata	22.56263	88.36304	India	Asia/Kolkata
+Gangasagar	South 24 Parganas	21.647535	88.081215	India	Asia/Kolkata
 Kollam	Kollam	8.88113	76.58469	India	Asia/Kolkata
 Korba	Korba	22.3458	82.69633	India	Asia/Kolkata
 Kota	Kota	25.18254	75.83907	India	Asia/Kolkata

--- a/worldclockwidget/src/main/java/ch/corten/aha/utils/PlatformClock.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/utils/PlatformClock.java
@@ -24,6 +24,6 @@ public class PlatformClock
 
     @Override
     public Moment currentTime() {
-        return this.zonalClock.currentMoment();
+        return this.zonalClock.now().inStdTimezone();
     }
 }

--- a/worldclockwidget/src/main/java/ch/corten/aha/utils/PlatformClock.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/utils/PlatformClock.java
@@ -1,0 +1,29 @@
+package ch.corten.aha.utils;
+
+import net.time4j.Moment;
+import net.time4j.SystemClock;
+import net.time4j.ZonalClock;
+import net.time4j.base.TimeSource;
+
+/**
+ * A special clock which takes into account possible adjustments of device clock done by app users
+ * if they intend to compensate wrong platform timezone data.
+ *
+ * @author  Meno Hochschild
+ */
+public class PlatformClock
+    implements TimeSource<Moment> {
+
+    public static final TimeSource<Moment> INSTANCE = new PlatformClock();
+
+    private final ZonalClock zonalClock = SystemClock.inPlatformView();
+
+    private PlatformClock() {
+        // singleton constructor
+    }
+
+    @Override
+    public Moment currentTime() {
+        return this.zonalClock.currentMoment();
+    }
+}

--- a/worldclockwidget/src/main/java/ch/corten/aha/widget/DigitalClock.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/widget/DigitalClock.java
@@ -34,6 +34,8 @@ import net.time4j.tz.Timezone;
 
 import java.util.Locale;
 
+import ch.corten.aha.utils.PlatformClock;
+
 /**
  * Like AnalogClock, but digital.  Shows seconds.
  *
@@ -181,7 +183,7 @@ public class DigitalClock extends TextView implements PauseListener {
     }
 
     private void updateClock() {
-        setText(mDateFormat.format(net.time4j.SystemClock.currentMoment()));
+        setText(mDateFormat.format(PlatformClock.INSTANCE.currentTime()));
         invalidate();
     }
 

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/AddClockActivity.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/AddClockActivity.java
@@ -40,8 +40,10 @@ import com.actionbarsherlock.view.MenuItem;
 import com.actionbarsherlock.widget.SearchView;
 import com.actionbarsherlock.widget.SearchView.OnQueryTextListener;
 
+import net.time4j.Moment;
 import net.time4j.tz.Timezone;
 
+import ch.corten.aha.utils.PlatformClock;
 import ch.corten.aha.worldclock.provider.WorldClock;
 import ch.corten.aha.worldclock.provider.WorldClock.Cities;
 
@@ -97,9 +99,10 @@ public class AddClockActivity extends SherlockFragmentActivity {
                     BindHelper.bindText(view, cursor, R.id.area_text, Cities.COUNTRY);
                     TextView timeDiffText = (TextView) view.findViewById(R.id.time_diff_text);
                     Timezone tz = Timezone.of(cursor.getString(cursor.getColumnIndex(Cities.TIMEZONE_ID)));
-                    timeDiffText.setText(TimeZoneInfo.getTimeDifferenceString(tz));
+                    Moment moment = PlatformClock.INSTANCE.currentTime();
+                    timeDiffText.setText(TimeZoneInfo.getTimeDifferenceString(tz, moment));
                     TextView timeZoneDescText = (TextView) view.findViewById(R.id.timezone_desc_text);
-                    timeZoneDescText.setText(TimeZoneInfo.getDescription(tz));
+                    timeZoneDescText.setText(TimeZoneInfo.getDescription(tz, moment));
                 }
             };
             setListAdapter(mAdapter);
@@ -191,7 +194,8 @@ public class AddClockActivity extends SherlockFragmentActivity {
                 String timeZoneId = c.getString(c.getColumnIndex(Cities.TIMEZONE_ID));
                 String city = c.getString(c.getColumnIndex(Cities.NAME));
                 String country = c.getString(c.getColumnIndex(Cities.COUNTRY));
-                int timeDiff = TimeZoneInfo.getTimeDifference(Timezone.of(timeZoneId));
+                Moment moment = PlatformClock.INSTANCE.currentTime();
+                int timeDiff = TimeZoneInfo.getTimeDifference(Timezone.of(timeZoneId), moment);
                 double latitude = c.getDouble(c.getColumnIndex(Cities.LATITUDE));
                 double longitude = c.getDouble(c.getColumnIndex(Cities.LONGITUDE));
                 WorldClock.Clocks.addClock(getActivity(), timeZoneId, city,

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/AddClockActivity.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/AddClockActivity.java
@@ -40,7 +40,7 @@ import com.actionbarsherlock.view.MenuItem;
 import com.actionbarsherlock.widget.SearchView;
 import com.actionbarsherlock.widget.SearchView.OnQueryTextListener;
 
-import org.joda.time.DateTimeZone;
+import net.time4j.tz.Timezone;
 
 import ch.corten.aha.worldclock.provider.WorldClock;
 import ch.corten.aha.worldclock.provider.WorldClock.Cities;
@@ -96,7 +96,7 @@ public class AddClockActivity extends SherlockFragmentActivity {
                     BindHelper.bindText(view, cursor, R.id.city_text, Cities.NAME);
                     BindHelper.bindText(view, cursor, R.id.area_text, Cities.COUNTRY);
                     TextView timeDiffText = (TextView) view.findViewById(R.id.time_diff_text);
-                    DateTimeZone tz = DateTimeZone.forID(cursor.getString(cursor.getColumnIndex(Cities.TIMEZONE_ID)));
+                    Timezone tz = Timezone.of(cursor.getString(cursor.getColumnIndex(Cities.TIMEZONE_ID)));
                     timeDiffText.setText(TimeZoneInfo.getTimeDifferenceString(tz));
                     TextView timeZoneDescText = (TextView) view.findViewById(R.id.timezone_desc_text);
                     timeZoneDescText.setText(TimeZoneInfo.getDescription(tz));
@@ -191,7 +191,7 @@ public class AddClockActivity extends SherlockFragmentActivity {
                 String timeZoneId = c.getString(c.getColumnIndex(Cities.TIMEZONE_ID));
                 String city = c.getString(c.getColumnIndex(Cities.NAME));
                 String country = c.getString(c.getColumnIndex(Cities.COUNTRY));
-                int timeDiff = TimeZoneInfo.getTimeDifference(DateTimeZone.forID(timeZoneId));
+                int timeDiff = TimeZoneInfo.getTimeDifference(Timezone.of(timeZoneId));
                 double latitude = c.getDouble(c.getColumnIndex(Cities.LATITUDE));
                 double longitude = c.getDouble(c.getColumnIndex(Cities.LONGITUDE));
                 WorldClock.Clocks.addClock(getActivity(), timeZoneId, city,

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/EditClockActivity.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/EditClockActivity.java
@@ -37,7 +37,7 @@ import com.actionbarsherlock.app.ActionBar;
 import com.actionbarsherlock.app.SherlockFragment;
 import com.actionbarsherlock.app.SherlockFragmentActivity;
 
-import org.joda.time.DateTimeZone;
+import net.time4j.tz.Timezone;
 
 import ch.corten.aha.worldclock.provider.WorldClock.Clocks;
 
@@ -128,7 +128,7 @@ public class EditClockActivity extends SherlockFragmentActivity {
                 mUseInWidgetCheckBox = (CheckBox) view.findViewById(R.id.use_in_widget_checkbox);
                 mUseInWidgetCheckBox.setChecked(c.getInt(c.getColumnIndex(Clocks.USE_IN_WIDGET)) != 0);
                 String id = c.getString(c.getColumnIndex(Clocks.TIMEZONE_ID));
-                DateTimeZone tz = DateTimeZone.forID(id);
+                Timezone tz = Timezone.of(id);
                 ((TextView) view.findViewById(R.id.time_zone_name)).setText(TimeZoneInfo.getDescription(tz));
                 ((TextView) view.findViewById(R.id.time_zone_details)).setText(TimeZoneInfo.getTimeDifferenceString(tz));
 

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/EditClockActivity.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/EditClockActivity.java
@@ -37,8 +37,10 @@ import com.actionbarsherlock.app.ActionBar;
 import com.actionbarsherlock.app.SherlockFragment;
 import com.actionbarsherlock.app.SherlockFragmentActivity;
 
+import net.time4j.Moment;
 import net.time4j.tz.Timezone;
 
+import ch.corten.aha.utils.PlatformClock;
 import ch.corten.aha.worldclock.provider.WorldClock.Clocks;
 
 public class EditClockActivity extends SherlockFragmentActivity {
@@ -129,8 +131,11 @@ public class EditClockActivity extends SherlockFragmentActivity {
                 mUseInWidgetCheckBox.setChecked(c.getInt(c.getColumnIndex(Clocks.USE_IN_WIDGET)) != 0);
                 String id = c.getString(c.getColumnIndex(Clocks.TIMEZONE_ID));
                 Timezone tz = Timezone.of(id);
-                ((TextView) view.findViewById(R.id.time_zone_name)).setText(TimeZoneInfo.getDescription(tz));
-                ((TextView) view.findViewById(R.id.time_zone_details)).setText(TimeZoneInfo.getTimeDifferenceString(tz));
+                Moment moment = PlatformClock.INSTANCE.currentTime();
+                ((TextView) view.findViewById(R.id.time_zone_name)).setText(
+                        TimeZoneInfo.getDescription(tz, moment));
+                ((TextView) view.findViewById(R.id.time_zone_details)).setText(
+                        TimeZoneInfo.getTimeDifferenceString(tz, moment));
 
                 if (SANS_ICE_CREAM) {
                     // capitalize text of the checkbox - pre ics does not support textAllCaps.

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/MyApp.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/MyApp.java
@@ -18,7 +18,7 @@ package ch.corten.aha.worldclock;
 
 import android.app.Application;
 
-import net.danlew.android.joda.JodaTimeAndroid;
+import net.time4j.android.ApplicationStarter;
 
 /**
  * Initializes libraries.
@@ -28,6 +28,6 @@ public class MyApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        JodaTimeAndroid.init(this);
+        ApplicationStarter.initialize(this);
     }
 }

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/TimeZoneInfo.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/TimeZoneInfo.java
@@ -17,9 +17,9 @@
 package ch.corten.aha.worldclock;
 
 import net.time4j.Moment;
-import net.time4j.SystemClock;
 import net.time4j.TemporalType;
 import net.time4j.base.TimeSource;
+import net.time4j.base.UnixTime;
 import net.time4j.format.expert.ChronoFormatter;
 import net.time4j.format.expert.PatternType;
 import net.time4j.tz.NameStyle;
@@ -32,6 +32,8 @@ import java.text.SimpleDateFormat;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import ch.corten.aha.utils.PlatformClock;
+
 public final class TimeZoneInfo {
 
     private static final String WEEKDAY_FORMAT = "EEE";
@@ -40,7 +42,7 @@ public final class TimeZoneInfo {
     }
 
     public static int getTimeDifference(Timezone tz) { // in minutes
-        return tz.getOffset(SystemClock.currentMoment()).getIntegralAmount() / 60;
+        return tz.getOffset(PlatformClock.INSTANCE.currentTime()).getIntegralAmount() / 60;
     }
 
     public static String formatDate(DateFormat dateFormat, TZID tzid, TimeSource<Moment> clock) {
@@ -80,7 +82,7 @@ public final class TimeZoneInfo {
 
     public static String getDescription(Timezone tz) {
         NameStyle style =
-                tz.isDaylightSaving(SystemClock.currentMoment())
+                tz.isDaylightSaving(PlatformClock.INSTANCE.currentTime())
                         ? NameStyle.LONG_DAYLIGHT_TIME
                         : NameStyle.LONG_STANDARD_TIME;
         return tz.getDisplayName(style, Locale.getDefault());
@@ -98,7 +100,7 @@ public final class TimeZoneInfo {
      * @return a Java {@link java.util.TimeZone} with the same offset for the given time.
      */
     public static TimeZone convertToJavaTimeZone(TZID tzid, TimeSource<?> clock) {
-        Moment ut = Moment.from(clock.currentTime());
+        UnixTime ut = clock.currentTime();
         TimeZone timeZone = TimeZone.getTimeZone(tzid.canonical());
         ZonalOffset offset = Timezone.of(tzid).getOffset(ut);
         int platformOffsetInSecs = timeZone.getOffset(ut.getPosixTime() * 1000L) / 1000;

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/TimeZoneInfo.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/TimeZoneInfo.java
@@ -16,44 +16,46 @@
 
 package ch.corten.aha.worldclock;
 
-import android.util.Log;
-
-import org.joda.time.DateTimeUtils;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.DateTimeFormat;
-import org.joda.time.format.DateTimeFormatter;
+import net.time4j.Moment;
+import net.time4j.SystemClock;
+import net.time4j.TemporalType;
+import net.time4j.base.TimeSource;
+import net.time4j.format.expert.ChronoFormatter;
+import net.time4j.format.expert.PatternType;
+import net.time4j.tz.NameStyle;
+import net.time4j.tz.TZID;
+import net.time4j.tz.Timezone;
+import net.time4j.tz.ZonalOffset;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Date;
+import java.util.Locale;
 import java.util.TimeZone;
 
 public final class TimeZoneInfo {
 
     private static final String WEEKDAY_FORMAT = "EEE";
-    private static final String TZ_ID_TAG = "TZ-IDs";
 
     private TimeZoneInfo() {
     }
 
-    public static int getTimeDifference(DateTimeZone tz) {
-        int milliseconds = tz.getOffset(DateTimeUtils.currentTimeMillis());
-        return milliseconds / 60000;
+    public static int getTimeDifference(Timezone tz) { // in minutes
+        return tz.getOffset(SystemClock.currentMoment()).getIntegralAmount() / 60;
     }
 
-    public static String formatDate(DateFormat dateFormat, DateTimeZone tz, long time) {
+    public static String formatDate(DateFormat dateFormat, TZID tzid, TimeSource<Moment> clock) {
         if (dateFormat instanceof SimpleDateFormat) {
             String pattern = ((SimpleDateFormat) dateFormat).toPattern();
-            DateTimeFormatter format = DateTimeFormat.forPattern(pattern).withZone(tz);
-            return format.print(time);
+            ChronoFormatter<Moment> cf =
+                    ChronoFormatter.ofMomentPattern(pattern, PatternType.CLDR, Locale.getDefault(), tzid);
+            return cf.format(clock.currentTime());
         } else {
-            dateFormat.setTimeZone(convertToJavaTimeZone(tz, time));
-            return dateFormat.format(new Date(time));
+            dateFormat.setTimeZone(convertToJavaTimeZone(tzid, clock));
+            return dateFormat.format(TemporalType.JAVA_UTIL_DATE.from(clock.currentTime()));
         }
     }
 
-    public static String getTimeDifferenceString(DateTimeZone tz) {
+    public static String getTimeDifferenceString(Timezone tz) {
         int minutesDiff = getTimeDifference(tz);
         StringBuilder sb = new StringBuilder();
         sb.append("UTC");
@@ -76,50 +78,56 @@ public final class TimeZoneInfo {
         return sb.toString();
     }
 
-    public static String getDescription(DateTimeZone tz) {
-        // The Java TimeZones gives a better description (and knows more time zones)
-        TimeZone timeZone = tz.toTimeZone();
-        if (timeZone.useDaylightTime() && timeZone.inDaylightTime(new Date())) {
-            return timeZone.getDisplayName(true, TimeZone.LONG);
-        }
-        return timeZone.getDisplayName();
+    public static String getDescription(Timezone tz) {
+        NameStyle style =
+                tz.isDaylightSaving(SystemClock.currentMoment())
+                        ? NameStyle.LONG_DAYLIGHT_TIME
+                        : NameStyle.LONG_STANDARD_TIME;
+        return tz.getDisplayName(style, Locale.getDefault());
     }
 
-    public static String showTimeWithOptionalWeekDay(DateTimeZone tz, long time, DateFormat df) {
-        return formatDate(df, tz, time) + showDifferentWeekday(tz, time);
+    public static String showTimeWithOptionalWeekDay(TZID tzid, TimeSource<Moment> clock, DateFormat df) {
+        return formatDate(df, tzid, clock) + showDifferentWeekday(tzid, clock);
     }
 
     /**
-     * Convert a joda-time {@link org.joda.time.DateTimeZone} to an equivalent Java {@link java.util.TimeZone}.
+     * Convert a Time4A {@link net.time4j.tz.Timezone} to an equivalent Java {@link java.util.TimeZone}.
      *
-     * @param dateTimeZone a joda-time {@link org.joda.time.DateTimeZone}
-     * @param time         the time when the time zones should be equivalent.
+     * @param tzid  the time zone id
+     * @param clock source of current time
      * @return a Java {@link java.util.TimeZone} with the same offset for the given time.
      */
-    public static TimeZone convertToJavaTimeZone(DateTimeZone dateTimeZone, long time) {
-        TimeZone timeZone = dateTimeZone.toTimeZone();
-        long offset = dateTimeZone.getOffset(time);
-        if (timeZone.getOffset(time) == offset) {
+    public static TimeZone convertToJavaTimeZone(TZID tzid, TimeSource<?> clock) {
+        Moment ut = Moment.from(clock.currentTime());
+        TimeZone timeZone = TimeZone.getTimeZone(tzid.canonical());
+        ZonalOffset offset = Timezone.of(tzid).getOffset(ut);
+        int platformOffsetInSecs = timeZone.getOffset(ut.getPosixTime() * 1000L) / 1000;
+        if (platformOffsetInSecs == offset.getIntegralAmount()) {
             return timeZone;
+        } else {
+            // let's now return the simple offset representation
+            // instead of searching for a potentially wrong replacement zone with same offset
+            return TimeZone.getTimeZone(offset.canonical());
         }
-        String[] ids = TimeZone.getAvailableIDs((int) offset);
-        Log.d(TZ_ID_TAG, dateTimeZone.getID() + ": " + Arrays.toString(ids));
-        for (String id : ids) {
-            TimeZone tz = TimeZone.getTimeZone(id);
-            if (tz.getOffset(time) == offset) {
-                timeZone = tz;
-                Log.d(TZ_ID_TAG, "Found time zone " + tz.getID() + " for " + dateTimeZone.getID() + " with offset: " + offset);
-                break;
-            }
-        }
-        return timeZone;
     }
 
-    public static String showDifferentWeekday(DateTimeZone tz, long time) {
-        DateTimeFormatter dayFormat = DateTimeFormat.forPattern(WEEKDAY_FORMAT).withZone(tz);
-        String day = dayFormat.print(time);
-        DateTimeFormatter localDayFormat = DateTimeFormat.forPattern(WEEKDAY_FORMAT);
-        if (!day.equals(localDayFormat.print(time))) {
+    public static String showDifferentWeekday(TZID tzid, TimeSource<Moment> clock) {
+        ChronoFormatter<Moment> dayFormat =
+                ChronoFormatter.ofMomentPattern(
+                        WEEKDAY_FORMAT,
+                        PatternType.CLDR,
+                        Locale.getDefault(),
+                        tzid);
+        ChronoFormatter<Moment> localDayFormat =
+                ChronoFormatter.ofMomentPattern(
+                        WEEKDAY_FORMAT,
+                        PatternType.CLDR,
+                        Locale.getDefault(),
+                        Timezone.ofSystem().getID());
+        Moment now = clock.currentTime();
+        String day = dayFormat.format(now);
+        String localDay = localDayFormat.format(now);
+        if (!day.equals(localDay)) {
             return " " + day;
         }
         return "";

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/UpdateWeatherService.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/UpdateWeatherService.java
@@ -106,7 +106,7 @@ public class UpdateWeatherService extends IntentService {
         String OWM_API_KEY =prefs.getString(context.getString(R.string.new_api_key),null);
         Log.e(TAG,"New key from preferance: "+OWM_API_KEY+ "*******************************************************************");
 
-        WeatherService service = new AndroidWeatherServiceFactory().createService("owm",OWM_API_KEY);
+        WeatherService service = new AndroidWeatherServiceFactory().createService("owm",OWM_API_KEY,context);
         service.setLanguage(context.getString(R.string.weather_service_language));
 
         try {

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WeatherWidget.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WeatherWidget.java
@@ -30,7 +30,6 @@ import android.preference.PreferenceManager;
 import android.widget.RemoteViews;
 
 import net.time4j.Moment;
-import net.time4j.SystemClock;
 import net.time4j.base.TimeSource;
 import net.time4j.tz.TZID;
 import net.time4j.tz.Timezone;
@@ -38,6 +37,7 @@ import net.time4j.tz.Timezone;
 import java.text.DateFormat;
 import java.util.TimeZone;
 
+import ch.corten.aha.utils.PlatformClock;
 import ch.corten.aha.widget.RemoteViewUtil;
 import ch.corten.aha.worldclock.provider.WorldClock.Clocks;
 
@@ -73,7 +73,7 @@ public final class WeatherWidget {
 
         String id = cursor.getString(cursor.getColumnIndex(Clocks.TIMEZONE_ID));
         TZID tzid = Timezone.of(id).getID();
-        TimeSource<Moment > clock = SystemClock.INSTANCE;
+        TimeSource<Moment > clock = PlatformClock.INSTANCE;
         if (SANS_JELLY_BEAN_MR1) {
             rv.setTextViewText(R.id.time_text, TimeZoneInfo.showTimeWithOptionalWeekDay(tzid, clock, timeFormat));
         } else {

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WeatherWidget.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WeatherWidget.java
@@ -16,24 +16,27 @@
 
 package ch.corten.aha.worldclock;
 
-import java.text.DateFormat;
-import java.util.TimeZone;
-
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.graphics.Bitmap;
+import android.graphics.Bitmap.Config;
 import android.graphics.Canvas;
 import android.graphics.Color;
-import android.graphics.Bitmap.Config;
 import android.graphics.PorterDuff.Mode;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import android.widget.RemoteViews;
 
-import org.joda.time.DateTimeUtils;
-import org.joda.time.DateTimeZone;
+import net.time4j.Moment;
+import net.time4j.SystemClock;
+import net.time4j.base.TimeSource;
+import net.time4j.tz.TZID;
+import net.time4j.tz.Timezone;
+
+import java.text.DateFormat;
+import java.util.TimeZone;
 
 import ch.corten.aha.widget.RemoteViewUtil;
 import ch.corten.aha.worldclock.provider.WorldClock.Clocks;
@@ -69,14 +72,14 @@ public final class WeatherWidget {
         rv.setTextViewText(R.id.city_text, cursor.getString(cursor.getColumnIndex(Clocks.CITY)));
 
         String id = cursor.getString(cursor.getColumnIndex(Clocks.TIMEZONE_ID));
-        long now = DateTimeUtils.currentTimeMillis();
-        DateTimeZone tz = DateTimeZone.forID(id);
+        TZID tzid = Timezone.of(id).getID();
+        TimeSource<Moment > clock = SystemClock.INSTANCE;
         if (SANS_JELLY_BEAN_MR1) {
-            rv.setTextViewText(R.id.time_text, TimeZoneInfo.showTimeWithOptionalWeekDay(tz, now, timeFormat));
+            rv.setTextViewText(R.id.time_text, TimeZoneInfo.showTimeWithOptionalWeekDay(tzid, clock, timeFormat));
         } else {
-            TimeZone javaTimeZone = TimeZoneInfo.convertToJavaTimeZone(tz, now);
+            TimeZone javaTimeZone = TimeZoneInfo.convertToJavaTimeZone(tzid, clock);
             RemoteViewUtil.setTextClockTimeZone(rv, R.id.time_text, javaTimeZone.getID());
-            rv.setTextViewText(R.id.weekday_text, TimeZoneInfo.showDifferentWeekday(tz, now));
+            rv.setTextViewText(R.id.weekday_text, TimeZoneInfo.showDifferentWeekday(tzid, clock));
         }
 
         rv.setTextViewText(R.id.condition_text, cursor

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WeatherWidget.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WeatherWidget.java
@@ -30,7 +30,6 @@ import android.preference.PreferenceManager;
 import android.widget.RemoteViews;
 
 import net.time4j.Moment;
-import net.time4j.base.TimeSource;
 import net.time4j.tz.TZID;
 import net.time4j.tz.Timezone;
 
@@ -73,13 +72,13 @@ public final class WeatherWidget {
 
         String id = cursor.getString(cursor.getColumnIndex(Clocks.TIMEZONE_ID));
         TZID tzid = Timezone.of(id).getID();
-        TimeSource<Moment > clock = PlatformClock.INSTANCE;
+        Moment moment = PlatformClock.INSTANCE.currentTime();
         if (SANS_JELLY_BEAN_MR1) {
-            rv.setTextViewText(R.id.time_text, TimeZoneInfo.showTimeWithOptionalWeekDay(tzid, clock, timeFormat));
+            rv.setTextViewText(R.id.time_text, TimeZoneInfo.showTimeWithOptionalWeekDay(tzid, moment, timeFormat));
         } else {
-            TimeZone javaTimeZone = TimeZoneInfo.convertToJavaTimeZone(tzid, clock);
+            TimeZone javaTimeZone = TimeZoneInfo.convertToJavaTimeZone(tzid, moment);
             RemoteViewUtil.setTextClockTimeZone(rv, R.id.time_text, javaTimeZone.getID());
-            rv.setTextViewText(R.id.weekday_text, TimeZoneInfo.showDifferentWeekday(tzid, clock));
+            rv.setTextViewText(R.id.weekday_text, TimeZoneInfo.showDifferentWeekday(tzid, moment));
         }
 
         rv.setTextViewText(R.id.condition_text, cursor

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WorldClockActivity.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WorldClockActivity.java
@@ -326,6 +326,9 @@ public class WorldClockActivity extends SherlockFragmentActivity {
         public boolean onOptionsItemSelected(MenuItem item) {
             switch (item.getItemId()) {
             case R.id.menu_add:
+                //#TODO: Try to add logic find the city from gps and add them below is the example to add the clock
+                // check if the city is already added then send message already added.
+                //WorldClock.Clocks.addClock(getActivity(), "Asia/Kolkata", "Gangasagar","India", 330, 21.647535, 88.081215);
                 addClock();
                 return true;
             case R.id.menu_refresh:

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WorldClockActivity.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WorldClockActivity.java
@@ -49,8 +49,8 @@ import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuInflater;
 import com.actionbarsherlock.view.MenuItem;
 
-import org.joda.time.DateTimeUtils;
-import org.joda.time.DateTimeZone;
+import net.time4j.SystemClock;
+import net.time4j.tz.Timezone;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -87,7 +87,7 @@ public class WorldClockActivity extends SherlockFragmentActivity {
         private ActionMode mMode;
         private OnSharedPreferenceChangeListener mSpChange;
         private boolean mAutoSortClocks;
-        private final List<PauseListener> mListeners = new ArrayList<PauseListener>();
+        private final List<PauseListener> mListeners = new ArrayList<>();
 
         private static final String[] CLOCKS_PROJECTION = {
             Clocks._ID,
@@ -199,7 +199,7 @@ public class WorldClockActivity extends SherlockFragmentActivity {
         @Override
         public void removePauseListener(PauseListener listener) {
             mListeners.remove(listener);
-        };
+        }
 
         private void setupCabOld(ListView listView) {
             listView.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE);
@@ -462,10 +462,10 @@ public class WorldClockActivity extends SherlockFragmentActivity {
             BindHelper.bindText(view, cursor, R.id.area_text, Clocks.AREA);
 
             String timeZoneId = cursor.getString(cursor.getColumnIndex(Clocks.TIMEZONE_ID));
-            DateTimeZone tz = DateTimeZone.forID(timeZoneId);
+            Timezone tz = Timezone.of(timeZoneId);
             java.text.DateFormat df = DateFormat.getDateFormat(context);
             TextView dateText = (TextView) view.findViewById(R.id.date_text);
-            dateText.setText(TimeZoneInfo.formatDate(df, tz, DateTimeUtils.currentTimeMillis()));
+            dateText.setText(TimeZoneInfo.formatDate(df, tz.getID(), SystemClock.INSTANCE));
 
             TextView timeDiffText = (TextView) view.findViewById(R.id.time_diff_text);
             timeDiffText.setText(TimeZoneInfo.getTimeDifferenceString(tz));

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WorldClockActivity.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WorldClockActivity.java
@@ -49,6 +49,7 @@ import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuInflater;
 import com.actionbarsherlock.view.MenuItem;
 
+import net.time4j.Moment;
 import net.time4j.tz.Timezone;
 
 import java.text.MessageFormat;
@@ -463,12 +464,13 @@ public class WorldClockActivity extends SherlockFragmentActivity {
 
             String timeZoneId = cursor.getString(cursor.getColumnIndex(Clocks.TIMEZONE_ID));
             Timezone tz = Timezone.of(timeZoneId);
+            Moment moment = PlatformClock.INSTANCE.currentTime();
             java.text.DateFormat df = DateFormat.getDateFormat(context);
             TextView dateText = (TextView) view.findViewById(R.id.date_text);
-            dateText.setText(TimeZoneInfo.formatDate(df, tz.getID(), PlatformClock.INSTANCE));
+            dateText.setText(TimeZoneInfo.formatDate(df, tz.getID(), moment));
 
             TextView timeDiffText = (TextView) view.findViewById(R.id.time_diff_text);
-            timeDiffText.setText(TimeZoneInfo.getTimeDifferenceString(tz));
+            timeDiffText.setText(TimeZoneInfo.getTimeDifferenceString(tz, moment));
             DigitalClock clock = (DigitalClock) view.findViewById(R.id.time_clock);
             clock.setTimeZone(tz);
 

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WorldClockActivity.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WorldClockActivity.java
@@ -49,13 +49,13 @@ import com.actionbarsherlock.view.Menu;
 import com.actionbarsherlock.view.MenuInflater;
 import com.actionbarsherlock.view.MenuItem;
 
-import net.time4j.SystemClock;
 import net.time4j.tz.Timezone;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
+import ch.corten.aha.utils.PlatformClock;
 import ch.corten.aha.widget.DigitalClock;
 import ch.corten.aha.widget.PauseListener;
 import ch.corten.aha.widget.PauseSource;
@@ -465,7 +465,7 @@ public class WorldClockActivity extends SherlockFragmentActivity {
             Timezone tz = Timezone.of(timeZoneId);
             java.text.DateFormat df = DateFormat.getDateFormat(context);
             TextView dateText = (TextView) view.findViewById(R.id.date_text);
-            dateText.setText(TimeZoneInfo.formatDate(df, tz.getID(), SystemClock.INSTANCE));
+            dateText.setText(TimeZoneInfo.formatDate(df, tz.getID(), PlatformClock.INSTANCE));
 
             TextView timeDiffText = (TextView) view.findViewById(R.id.time_diff_text);
             timeDiffText.setText(TimeZoneInfo.getTimeDifferenceString(tz));

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WorldClockWidgetProvider.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WorldClockWidgetProvider.java
@@ -19,6 +19,7 @@ package ch.corten.aha.worldclock;
 import java.text.DateFormat;
 import java.util.TimeZone;
 
+import ch.corten.aha.utils.PlatformClock;
 import ch.corten.aha.widget.RemoteViewUtil;
 import ch.corten.aha.worldclock.provider.WorldClock.Clocks;
 
@@ -36,7 +37,6 @@ import android.view.View;
 import android.widget.RemoteViews;
 
 import net.time4j.Moment;
-import net.time4j.SystemClock;
 import net.time4j.base.TimeSource;
 import net.time4j.tz.TZID;
 import net.time4j.tz.Timezone;
@@ -104,7 +104,7 @@ public class WorldClockWidgetProvider extends ClockWidgetProvider {
                 String city = cursor.getString(cursor.getColumnIndex(Clocks.CITY));
                 views.setTextViewText(CITY_IDS[n], city);
                 TZID tzid = Timezone.of(id).getID();
-                TimeSource<Moment> clock = SystemClock.INSTANCE;
+                TimeSource<Moment> clock = PlatformClock.INSTANCE;
                 if (SANS_JELLY_BEAN_MR1) {
                     views.setTextViewText(TIME_IDS[n], TimeZoneInfo.formatDate(df, tzid, clock));
                 } else {

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WorldClockWidgetProvider.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WorldClockWidgetProvider.java
@@ -37,7 +37,6 @@ import android.view.View;
 import android.widget.RemoteViews;
 
 import net.time4j.Moment;
-import net.time4j.base.TimeSource;
 import net.time4j.tz.TZID;
 import net.time4j.tz.Timezone;
 
@@ -98,17 +97,17 @@ public class WorldClockWidgetProvider extends ClockWidgetProvider {
             int n = 0;
             DateFormat df = android.text.format.DateFormat.getTimeFormat(context);
             final int maxEntries = context.getResources().getInteger(R.integer.worldclock_widget_max_entries);
+            Moment moment = PlatformClock.INSTANCE.currentTime();
             while (cursor.moveToNext() && n < CITY_IDS.length
                     && n < maxEntries) {
                 String id = cursor.getString(cursor.getColumnIndex(Clocks.TIMEZONE_ID));
                 String city = cursor.getString(cursor.getColumnIndex(Clocks.CITY));
                 views.setTextViewText(CITY_IDS[n], city);
                 TZID tzid = Timezone.of(id).getID();
-                TimeSource<Moment> clock = PlatformClock.INSTANCE;
                 if (SANS_JELLY_BEAN_MR1) {
-                    views.setTextViewText(TIME_IDS[n], TimeZoneInfo.formatDate(df, tzid, clock));
+                    views.setTextViewText(TIME_IDS[n], TimeZoneInfo.formatDate(df, tzid, moment));
                 } else {
-                    TimeZone javaTimeZone = TimeZoneInfo.convertToJavaTimeZone(tzid, clock);
+                    TimeZone javaTimeZone = TimeZoneInfo.convertToJavaTimeZone(tzid, moment);
                     views.setViewVisibility(TIME_IDS[n], View.VISIBLE);
                     RemoteViewUtil.setTextClockTimeZone(views, TIME_IDS[n], javaTimeZone.getID());
                 }

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WorldClockWidgetProvider.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/WorldClockWidgetProvider.java
@@ -35,8 +35,11 @@ import android.preference.PreferenceManager;
 import android.view.View;
 import android.widget.RemoteViews;
 
-import org.joda.time.DateTimeUtils;
-import org.joda.time.DateTimeZone;
+import net.time4j.Moment;
+import net.time4j.SystemClock;
+import net.time4j.base.TimeSource;
+import net.time4j.tz.TZID;
+import net.time4j.tz.Timezone;
 
 public class WorldClockWidgetProvider extends ClockWidgetProvider {
     private static final boolean SANS_JELLY_BEAN_MR1 = Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR1;
@@ -94,18 +97,18 @@ public class WorldClockWidgetProvider extends ClockWidgetProvider {
         try {
             int n = 0;
             DateFormat df = android.text.format.DateFormat.getTimeFormat(context);
-            long now = DateTimeUtils.currentTimeMillis();
             final int maxEntries = context.getResources().getInteger(R.integer.worldclock_widget_max_entries);
             while (cursor.moveToNext() && n < CITY_IDS.length
                     && n < maxEntries) {
                 String id = cursor.getString(cursor.getColumnIndex(Clocks.TIMEZONE_ID));
                 String city = cursor.getString(cursor.getColumnIndex(Clocks.CITY));
                 views.setTextViewText(CITY_IDS[n], city);
-                DateTimeZone tz = DateTimeZone.forID(id);
+                TZID tzid = Timezone.of(id).getID();
+                TimeSource<Moment> clock = SystemClock.INSTANCE;
                 if (SANS_JELLY_BEAN_MR1) {
-                    views.setTextViewText(TIME_IDS[n], TimeZoneInfo.formatDate(df, tz, now));
+                    views.setTextViewText(TIME_IDS[n], TimeZoneInfo.formatDate(df, tzid, clock));
                 } else {
-                    TimeZone javaTimeZone = TimeZoneInfo.convertToJavaTimeZone(tz, now);
+                    TimeZone javaTimeZone = TimeZoneInfo.convertToJavaTimeZone(tzid, clock);
                     views.setViewVisibility(TIME_IDS[n], View.VISIBLE);
                     RemoteViewUtil.setTextClockTimeZone(views, TIME_IDS[n], javaTimeZone.getID());
                 }

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/provider/CityDatabase.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/provider/CityDatabase.java
@@ -48,8 +48,8 @@ class CityDatabase extends SQLiteOpenHelper {
     private static final String DROP_TABLE = "drop table if exists cities";
 
     private static final String DATABASE_NAME = "cities";
-    private static final int DATABASE_VERSION = 19;
-
+    //private static final int DATABASE_VERSION = 19;
+    private static final int DATABASE_VERSION = 20;
     private Context mContext;
     private boolean mNeedsVacuum;
 

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/provider/WorldClock.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/provider/WorldClock.java
@@ -24,7 +24,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.provider.BaseColumns;
 
-import org.joda.time.DateTimeZone;
+import net.time4j.tz.Timezone;
 
 import ch.corten.aha.worldclock.TimeZoneInfo;
 import ch.corten.aha.worldclock.weather.WeatherObservation;
@@ -38,7 +38,7 @@ public final class WorldClock {
     public static final Uri AUTHORITY_URI = Uri.parse("content://" + AUTHORITY);
 
     public static class Clocks implements BaseColumns {
-        public static enum MoveTarget {
+        public enum MoveTarget {
             UP,
             DOWN
         }
@@ -197,7 +197,7 @@ public final class WorldClock {
                     while (c.moveToNext()) {
                         String timeZoneId = c.getString(c.getColumnIndex(TIMEZONE_ID));
                         int storedDiff = c.getInt(c.getColumnIndex(TIME_DIFF));
-                        DateTimeZone tz = DateTimeZone.forID(timeZoneId);
+                        Timezone tz = Timezone.of(timeZoneId);
                         int diff = TimeZoneInfo.getTimeDifference(tz);
                         if (storedDiff != diff) {
                             // update entry

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/provider/WorldClock.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/provider/WorldClock.java
@@ -24,8 +24,10 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.provider.BaseColumns;
 
+import net.time4j.Moment;
 import net.time4j.tz.Timezone;
 
+import ch.corten.aha.utils.PlatformClock;
 import ch.corten.aha.worldclock.TimeZoneInfo;
 import ch.corten.aha.worldclock.weather.WeatherObservation;
 
@@ -194,11 +196,12 @@ public final class WorldClock {
             Cursor c = cr.query(CONTENT_URI, new String[] {_ID, TIMEZONE_ID, TIME_DIFF}, null, null, _ID);
             if (c != null) {
                 try {
+                    Moment moment = PlatformClock.INSTANCE.currentTime();
                     while (c.moveToNext()) {
                         String timeZoneId = c.getString(c.getColumnIndex(TIMEZONE_ID));
                         int storedDiff = c.getInt(c.getColumnIndex(TIME_DIFF));
                         Timezone tz = Timezone.of(timeZoneId);
-                        int diff = TimeZoneInfo.getTimeDifference(tz);
+                        int diff = TimeZoneInfo.getTimeDifference(tz, moment);
                         if (storedDiff != diff) {
                             // update entry
                             long id = c.getLong(c.getColumnIndex(_ID));

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/weather/AndroidWeatherServiceFactory.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/weather/AndroidWeatherServiceFactory.java
@@ -54,7 +54,7 @@ public class AndroidWeatherServiceFactory implements WeatherServiceFactory {
                 Log.e(TAG, "Info:: performance key null detected.");
                 no_key = true;
             }
-            else if (owm_api_key.equals("Please enter new open weather map API"))
+            else if (owm_api_key.equals("Please enter new open weather map API key"))
             {
                 Log.e(TAG, "Info:: performance value is: Please enter new open weather map API.");
                 no_key = true;
@@ -74,7 +74,6 @@ public class AndroidWeatherServiceFactory implements WeatherServiceFactory {
                 Log.e(TAG, "Info:: New Key:" + new_api_key_from_file+".");
                 //Here setting the OWM_API_KEY to the OwmWeatherService class
                 api_key_value=new_api_key_from_file;
-
             }
             else
             {

--- a/worldclockwidget/src/main/java/ch/corten/aha/worldclock/weather/WeatherServiceFactory.java
+++ b/worldclockwidget/src/main/java/ch/corten/aha/worldclock/weather/WeatherServiceFactory.java
@@ -16,8 +16,10 @@
 
 package ch.corten.aha.worldclock.weather;
 
+import android.content.Context;
+
 public interface WeatherServiceFactory {
 
-    WeatherService createService(String provider,String owm_api_key);
+    WeatherService createService(String provider, String owm_api_key, Context mcontext);
 
 }


### PR DESCRIPTION
This first step is a library switch from Joda-Time-Android to Time4A. It enables the project to exploit the astronomical features of Time4A in order to solve the issue #46 (calculating sunrise/sunset).

Two minor optimizations had also been done:
- A project-wide unique clock instance had been introduced (`PlatformClock`) which also takes into account possible adjustments of mobile device clocks (done by app users as compensation for bad timezone data on old Android versions). The new clock logically replaces the Joda-method `DateTimeUtils.currentTimeMillis()`
-  Some method signatures in the class `TimeZoneInfo` had been enhanced by an extra moment-parameter in order to avoid multiple calls of current clock time inside the same method call.

Examples for calculating sunrise or sunset can be found in the documentation of class [SolarTime](http://time4j.net/javadoc-en/net/time4j/calendar/astro/SolarTime.html). 